### PR TITLE
Update perform play function to support tunnel cards

### DIFF
--- a/src/perform-play.ts
+++ b/src/perform-play.ts
@@ -6,7 +6,7 @@ import {
   RockfallActionCard,
   ToolActionCard,
 } from "./models/cards/action-cards";
-import { FinishPathCard, PathCard } from "./models/cards/path-cards";
+import { FinishPathCard, TunnelCard } from "./models/cards/path-cards";
 import Player from "./models/player";
 import Board from "./models/board";
 import {
@@ -30,6 +30,11 @@ function performToolAction(playedCard: ToolActionCard): void {
   }
 }
 
+function performPathAction(playedCard: TunnelCard, board: Board): void {
+  const { position } = playedCard.parameters as IBoardCardParameters;
+  board.addCard(playedCard, position);
+}
+
 function performRockfallAction(
   playedCard: RockfallActionCard,
   board: Board
@@ -49,16 +54,17 @@ function performMapAction(
 }
 
 function performPlay(
-  playedCard: ActionCard | PathCard,
+  playedCard: ActionCard | TunnelCard,
   player: Player,
   board: Board
 ): Card[] {
-  // TODO: Update the game state with passed in card
-  // If it's a path card - is it played against the board
-  //  - Do not return this card as it's not discarded
-
   if (!playedCard.parameters) {
     throw new Error("Missing action parameters");
+  }
+
+  if (playedCard instanceof TunnelCard) {
+    performPathAction(playedCard, board);
+    return []; // Tunnel cards are played to the board and not discarded
   }
 
   if (playedCard instanceof ToolActionCard) {
@@ -68,7 +74,7 @@ function performPlay(
 
   if (playedCard instanceof RockfallActionCard) {
     const removedCard = performRockfallAction(playedCard, board);
-    return [removedCard, playedCard];
+    return [removedCard, playedCard]; // Discard both the action card and the removed tunnel card
   }
 
   if (playedCard instanceof MapActionCard) {

--- a/src/tests/perform-play.test.ts
+++ b/src/tests/perform-play.test.ts
@@ -8,7 +8,7 @@ import {
 import Player from "../models/player";
 import Board, { middleFinishPosition } from "../models/board";
 import { Tools } from "../constants";
-import { PassageCard } from "../models/cards/path-cards";
+import { PassageCard, DeadendCard } from "../models/cards/path-cards";
 import Position from "../models/position";
 import performPlay from "../perform-play";
 
@@ -31,6 +31,40 @@ describe("performPlay", () => {
       expect(() => performPlay(actionCard, activePlayer, board)).toThrow(
         "Missing action parameters"
       );
+    });
+  });
+
+  describe("when PassageCard is played", () => {
+    let tunnelCard: PassageCard;
+
+    beforeEach(() => {
+      tunnelCard = new PassageCard([1, 2, 3, 4]);
+    });
+
+    it("adds the card to the board", () => {
+      expect(board.getCardAt(PLAY_POSITION)).toBe(undefined);
+
+      tunnelCard.play({ position: PLAY_POSITION });
+      performPlay(tunnelCard, activePlayer, board);
+
+      expect(board.getCardAt(PLAY_POSITION)).toBe(tunnelCard);
+    });
+  });
+
+  describe("when DeadendCard is played", () => {
+    let tunnelCard: PassageCard;
+
+    beforeEach(() => {
+      tunnelCard = new DeadendCard([1, 2, 3, 4]);
+    });
+
+    it("adds the card to the board", () => {
+      expect(board.getCardAt(PLAY_POSITION)).toBe(undefined);
+
+      tunnelCard.play({ position: PLAY_POSITION });
+      performPlay(tunnelCard, activePlayer, board);
+
+      expect(board.getCardAt(PLAY_POSITION)).toBe(tunnelCard);
     });
   });
 
@@ -86,23 +120,22 @@ describe("performPlay", () => {
   });
 
   describe("when RockfallActionCard is played", () => {
-    const position = PLAY_POSITION;
     let actionCard: RockfallActionCard;
     let passageCard: PassageCard;
 
     beforeEach(() => {
       actionCard = new RockfallActionCard();
       passageCard = new PassageCard([1, 2, 3, 4]);
-      board.addCard(passageCard, position);
+      board.addCard(passageCard, PLAY_POSITION);
     });
 
     it("removes the card from the board", () => {
-      expect(board.getCardAt(position)).toBe(passageCard);
+      expect(board.getCardAt(PLAY_POSITION)).toBe(passageCard);
 
-      actionCard.play({ position });
+      actionCard.play({ position: PLAY_POSITION });
       performPlay(actionCard, activePlayer, board);
 
-      expect(board.getCardAt(position)).toBe(undefined);
+      expect(board.getCardAt(PLAY_POSITION)).toBe(undefined);
     });
   });
 


### PR DESCRIPTION
This does not implement any of the validation for legal moves; that is
the responsibility of the game board to reject moves which are not
valid, and will be tackled in an upcoming commit.