### PR TITLE
Correct github actions commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: yarn install
-      - run: yarn lint
-      - run: yarn test
+      - run: npm install
+      - run: npm run lint
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "saboteur-engine",
   "version": "1.0.0",
-  "description": "",
+  "description": "Saboteur game engine",
   "main": "index.ts",
   "scripts": {
     "eslint": "eslint --ext .js,.jsx,.ts,.tsx .",
@@ -18,6 +18,12 @@
   "contributors": [
     "Alistair Brown <github@alistairjcbrown.com>"
   ],
+  "homepage": "https://github.com/saboteur-game/engine/",
+  "bugs": "https://github.com/saboteur-game/engine/issues",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:saboteur-game/engine.git"
+  },
   "license": "MIT",
   "dependencies": {
     "@types/uuid": "^8.0.0",


### PR DESCRIPTION
Update github actions to use npm instead of yarn. Using the wrong
package manager was causing warnings in the output on node binary used,
as well as not having a lock file in place.