### PR TITLE
Implement visual board output

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ This repository is a work in progress. Active tasks can be found on
    $  npm install
    ```
 
+### Running the example
+
+```
+$  npx ts-node ./example/index.ts
+```
+
 ### 🛠️ Tools
 
 #### 🧪 Testing

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,3 +1,7 @@
+import { PassageCard } from "../src/models/cards/path-cards";
+import { IBoardCardParameters } from "../src/models/cards/card-parameters";
+import { Sides } from "../src/models/cards/card";
+import Position from "../src/models/position";
 import { Game, Player } from "..";
 
 const game = new Game();
@@ -19,4 +23,28 @@ players.forEach((player) => {
 
 game.start();
 
-console.log(JSON.stringify(game, null, 4));
+for (let i = 1; i <= 5; i++) {
+  const player = game.getActivePlayer() as Player;
+  const playableCard = player
+    .getHand()
+    .find(
+      (card) =>
+        card instanceof PassageCard && card.connectors.includes(Sides.left)
+    );
+
+  if (playableCard) {
+    console.log((playableCard as PassageCard).visualize());
+    game.playCard(player, playableCard.id, {
+      position: new Position(i, 0),
+    } as IBoardCardParameters);
+  } else {
+    game.discardCard(player, player.getHand()[0].id);
+    i--;
+  }
+}
+
+console.log("\n-------------------------------------------------\n");
+console.log(game.visualizeBoard());
+console.log("\n-------------------------------------------------\n");
+
+// console.log(JSON.stringify(game, null, 4));

--- a/src/models/board.ts
+++ b/src/models/board.ts
@@ -39,6 +39,45 @@ class Board {
     };
   }
 
+  visualize(): string {
+    const dimensions = Object.keys(this.grid).reduce(
+      ({ top, right, bottom, left }, positionKey) => {
+        const [x, y] = positionKey
+          .split(",")
+          .map((value) => parseInt(value, 10));
+        return {
+          top: y > 0 ? Math.max(top, y) : top,
+          right: x > 0 ? Math.max(right, x) : right,
+          bottom: y < 0 ? Math.max(bottom, Math.abs(y)) * -1 : bottom,
+          left: x < 0 ? Math.max(left, Math.abs(x)) * -1 : left,
+        };
+      },
+      { top: 0, right: 0, bottom: 0, left: 0 }
+    );
+
+    const CARD_SPACE = "      \n      \n      \n";
+    const rowGrid = [];
+    for (let y = dimensions.top; y >= dimensions.bottom; y--) {
+      rowGrid.push([] as string[]);
+      for (let x = dimensions.left; x <= dimensions.right; x++) {
+        const card = this.getCardAt(new Position(x, y));
+        rowGrid[dimensions.top - y].push(!card ? CARD_SPACE : card.visualize());
+      }
+    }
+
+    const lineGrid = rowGrid.reduce(
+      (flattenedGrid, row) =>
+        flattenedGrid.concat(
+          [0, 1, 2].map((index) =>
+            row.map((item: string) => item.split("\n")[index])
+          )
+        ),
+      [] as string[][]
+    );
+
+    return lineGrid.map((row) => row.join("")).join("\n");
+  }
+
   addCard(card: PassageCard | DeadendCard, position: Position): void {
     if (!(card instanceof PassageCard) && !(card instanceof DeadendCard)) {
       throw new Error(`Invalid type of card provided`);

--- a/src/models/cards/path-cards/boundary-cards.ts
+++ b/src/models/cards/path-cards/boundary-cards.ts
@@ -1,9 +1,14 @@
 import { PathCard } from ".";
 import { Sides } from "../card";
+import getCardVisualization from "../../../utils/get-card-visualization";
 
 export class StartPathCard extends PathCard {
   constructor(isUpsideDown?: boolean) {
     super([Sides.top, Sides.right, Sides.bottom, Sides.left], isUpsideDown);
+  }
+
+  visualize(): string {
+    return getCardVisualization(this, "[]");
   }
 }
 
@@ -13,6 +18,14 @@ export class GoldFinishPathCard extends FinishPathCard {
   constructor(isUpsideDown?: boolean) {
     super([Sides.top, Sides.right, Sides.bottom, Sides.left], isUpsideDown);
   }
+
+  visualize(): string {
+    return getCardVisualization(this, "!!");
+  }
 }
 
-export class RockFinishPathCard extends FinishPathCard {}
+export class RockFinishPathCard extends FinishPathCard {
+  visualize(): string {
+    return getCardVisualization(this, "xx");
+  }
+}

--- a/src/models/cards/path-cards/path-card.ts
+++ b/src/models/cards/path-cards/path-card.ts
@@ -24,6 +24,10 @@ class PathCard extends Card {
     return this;
   }
 
+  visualize(): string {
+    throw new Error("Not implemented");
+  }
+
   toJS(): Pojo {
     return {
       ...super.toJS(),

--- a/src/models/cards/path-cards/tests/__snapshots__/boundary-cards.test.ts.snap
+++ b/src/models/cards/path-cards/tests/__snapshots__/boundary-cards.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Boundary Cards GoldFinishPathCard can be visualized 1`] = `
+"██  ██
+  !!  
+██  ██"
+`;
+
+exports[`Boundary Cards GoldFinishPathCard can be visualized right side up 1`] = `
+"██  ██
+██xx  
+██████"
+`;
+
+exports[`Boundary Cards GoldFinishPathCard can be visualized upside down 1`] = `
+"██████
+  xx██
+██  ██"
+`;
+
+exports[`Boundary Cards StartPathCard can be visualized 1`] = `
+"██  ██
+  []  
+██  ██"
+`;

--- a/src/models/cards/path-cards/tests/__snapshots__/tunnel-cards.test.ts.snap
+++ b/src/models/cards/path-cards/tests/__snapshots__/tunnel-cards.test.ts.snap
@@ -1,0 +1,193 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tunnel Cards DeadendCard right side up with [1, 2, 3, 4] configuration can be visualized 1`] = `
+"██  ██
+  ██  
+██  ██"
+`;
+
+exports[`Tunnel Cards DeadendCard right side up with [1, 2, 3] configuration can be visualized 1`] = `
+"██  ██
+████  
+██  ██"
+`;
+
+exports[`Tunnel Cards DeadendCard right side up with [1, 2, 4] configuration can be visualized 1`] = `
+"██  ██
+  ██  
+██████"
+`;
+
+exports[`Tunnel Cards DeadendCard right side up with [1, 2] configuration can be visualized 1`] = `
+"██  ██
+████  
+██████"
+`;
+
+exports[`Tunnel Cards DeadendCard right side up with [1, 3] configuration can be visualized 1`] = `
+"██  ██
+██████
+██  ██"
+`;
+
+exports[`Tunnel Cards DeadendCard right side up with [1, 4] configuration can be visualized 1`] = `
+"██  ██
+  ████
+██████"
+`;
+
+exports[`Tunnel Cards DeadendCard right side up with [1] configuration can be visualized 1`] = `
+"██  ██
+██████
+██████"
+`;
+
+exports[`Tunnel Cards DeadendCard right side up with [2, 4] configuration can be visualized 1`] = `
+"██████
+  ██  
+██████"
+`;
+
+exports[`Tunnel Cards DeadendCard right side up with [2] configuration can be visualized 1`] = `
+"██████
+████  
+██████"
+`;
+
+exports[`Tunnel Cards DeadendCard upside down with [1, 2, 3, 4] configuration can be visualized 1`] = `
+"██  ██
+  ██  
+██  ██"
+`;
+
+exports[`Tunnel Cards DeadendCard upside down with [1, 2, 3] configuration can be visualized 1`] = `
+"██  ██
+  ████
+██  ██"
+`;
+
+exports[`Tunnel Cards DeadendCard upside down with [1, 2, 4] configuration can be visualized 1`] = `
+"██████
+  ██  
+██  ██"
+`;
+
+exports[`Tunnel Cards DeadendCard upside down with [1, 2] configuration can be visualized 1`] = `
+"██████
+  ████
+██  ██"
+`;
+
+exports[`Tunnel Cards DeadendCard upside down with [1, 3] configuration can be visualized 1`] = `
+"██  ██
+██████
+██  ██"
+`;
+
+exports[`Tunnel Cards DeadendCard upside down with [1, 4] configuration can be visualized 1`] = `
+"██████
+████  
+██  ██"
+`;
+
+exports[`Tunnel Cards DeadendCard upside down with [1] configuration can be visualized 1`] = `
+"██████
+██████
+██  ██"
+`;
+
+exports[`Tunnel Cards DeadendCard upside down with [2, 4] configuration can be visualized 1`] = `
+"██████
+  ██  
+██████"
+`;
+
+exports[`Tunnel Cards DeadendCard upside down with [2] configuration can be visualized 1`] = `
+"██████
+  ████
+██████"
+`;
+
+exports[`Tunnel Cards PassageCard right side up with [1, 2, 3, 4] configuration can be visualized 1`] = `
+"██  ██
+      
+██  ██"
+`;
+
+exports[`Tunnel Cards PassageCard right side up with [1, 2, 3] configuration can be visualized 1`] = `
+"██  ██
+██    
+██  ██"
+`;
+
+exports[`Tunnel Cards PassageCard right side up with [1, 2, 4] configuration can be visualized 1`] = `
+"██  ██
+      
+██████"
+`;
+
+exports[`Tunnel Cards PassageCard right side up with [1, 2] configuration can be visualized 1`] = `
+"██  ██
+██    
+██████"
+`;
+
+exports[`Tunnel Cards PassageCard right side up with [1, 3] configuration can be visualized 1`] = `
+"██  ██
+██  ██
+██  ██"
+`;
+
+exports[`Tunnel Cards PassageCard right side up with [1, 4] configuration can be visualized 1`] = `
+"██  ██
+    ██
+██████"
+`;
+
+exports[`Tunnel Cards PassageCard right side up with [2, 4] configuration can be visualized 1`] = `
+"██████
+      
+██████"
+`;
+
+exports[`Tunnel Cards PassageCard upside down with [1, 2, 3, 4] configuration can be visualized 1`] = `
+"██  ██
+      
+██  ██"
+`;
+
+exports[`Tunnel Cards PassageCard upside down with [1, 2, 3] configuration can be visualized 1`] = `
+"██  ██
+    ██
+██  ██"
+`;
+
+exports[`Tunnel Cards PassageCard upside down with [1, 2, 4] configuration can be visualized 1`] = `
+"██████
+      
+██  ██"
+`;
+
+exports[`Tunnel Cards PassageCard upside down with [1, 2] configuration can be visualized 1`] = `
+"██████
+    ██
+██  ██"
+`;
+
+exports[`Tunnel Cards PassageCard upside down with [1, 3] configuration can be visualized 1`] = `
+"██  ██
+██  ██
+██  ██"
+`;
+
+exports[`Tunnel Cards PassageCard upside down with [1, 4] configuration can be visualized 1`] = `
+"██████
+██    
+██  ██"
+`;
+
+exports[`Tunnel Cards PassageCard upside down with [2, 4] configuration can be visualized 1`] = `
+"██████
+      
+██████"
+`;

--- a/src/models/cards/path-cards/tests/boundary-cards.test.ts
+++ b/src/models/cards/path-cards/tests/boundary-cards.test.ts
@@ -1,0 +1,30 @@
+import { Sides } from "../../card";
+import { StartPathCard, GoldFinishPathCard, RockFinishPathCard } from "..";
+
+describe("Boundary Cards", () => {
+  describe("StartPathCard", () => {
+    it("can be visualized", () => {
+      expect(new StartPathCard().visualize()).toMatchSnapshot();
+    });
+  });
+
+  describe("GoldFinishPathCard", () => {
+    it("can be visualized", () => {
+      expect(new GoldFinishPathCard().visualize()).toMatchSnapshot();
+    });
+  });
+
+  describe("GoldFinishPathCard", () => {
+    it("can be visualized right side up", () => {
+      expect(
+        new RockFinishPathCard([Sides.top, Sides.right], false).visualize()
+      ).toMatchSnapshot();
+    });
+
+    it("can be visualized upside down", () => {
+      expect(
+        new RockFinishPathCard([Sides.top, Sides.right], true).visualize()
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/src/models/cards/path-cards/tests/path-card.test.ts
+++ b/src/models/cards/path-cards/tests/path-card.test.ts
@@ -18,6 +18,10 @@ describe("PathCard", () => {
     expect(pathCard.toJS()).toMatchSnapshot();
   });
 
+  it("does not implement visalization", () => {
+    expect(() => pathCard.visualize()).toThrow("Not implemented");
+  });
+
   it("can be rotated", () => {
     expect(pathCard.isUpsideDown).toBe(false);
     pathCard.rotate();

--- a/src/models/cards/path-cards/tests/tunnel-cards.test.ts
+++ b/src/models/cards/path-cards/tests/tunnel-cards.test.ts
@@ -1,0 +1,62 @@
+import { Sides } from "../../card";
+import { PassageCard, DeadendCard } from "..";
+
+describe("Tunnel Cards", () => {
+  describe("PassageCard", () => {
+    const passageConfigurations = [
+      [[Sides.right, Sides.left]],
+      [[Sides.top, Sides.bottom]],
+      [[Sides.top, Sides.left]],
+      [[Sides.top, Sides.right]],
+      [[Sides.top, Sides.right, Sides.left]],
+      [[Sides.top, Sides.right, Sides.bottom]],
+      [[Sides.top, Sides.right, Sides.bottom, Sides.left]],
+    ];
+
+    describe.each([
+      ["right side up", false],
+      ["upside down", true],
+    ])("%s", (message, direction) => {
+      describe.each(passageConfigurations)(
+        "with %p configuration",
+        (connections) => {
+          it("can be visualized", () => {
+            expect(
+              new PassageCard(connections, direction).visualize()
+            ).toMatchSnapshot();
+          });
+        }
+      );
+    });
+  });
+
+  describe("DeadendCard", () => {
+    const deadendConfigurations = [
+      [[Sides.top]],
+      [[Sides.right]],
+      [[Sides.top, Sides.right]],
+      [[Sides.top, Sides.bottom]],
+      [[Sides.top, Sides.left]],
+      [[Sides.right, Sides.left]],
+      [[Sides.top, Sides.right, Sides.bottom]],
+      [[Sides.top, Sides.right, Sides.left]],
+      [[Sides.top, Sides.right, Sides.bottom, Sides.left]],
+    ];
+
+    describe.each([
+      ["right side up", false],
+      ["upside down", true],
+    ])("%s", (message, direction) => {
+      describe.each(deadendConfigurations)(
+        "with %p configuration",
+        (connections) => {
+          it("can be visualized", () => {
+            expect(
+              new DeadendCard(connections, direction).visualize()
+            ).toMatchSnapshot();
+          });
+        }
+      );
+    });
+  });
+});

--- a/src/models/cards/path-cards/tunnel-cards.ts
+++ b/src/models/cards/path-cards/tunnel-cards.ts
@@ -1,7 +1,16 @@
 import { PathCard } from ".";
+import getCardVisualization from "../../../utils/get-card-visualization";
 
 export class TunnelCard extends PathCard {}
 
-export class PassageCard extends TunnelCard {}
+export class PassageCard extends TunnelCard {
+  visualize(): string {
+    return getCardVisualization(this);
+  }
+}
 
-export class DeadendCard extends TunnelCard {}
+export class DeadendCard extends TunnelCard {
+  visualize(): string {
+    return getCardVisualization(this, "██");
+  }
+}

--- a/src/models/game.ts
+++ b/src/models/game.ts
@@ -171,6 +171,10 @@ class Game {
     return this.discard.getTopCard();
   }
 
+  visualizeBoard(): string {
+    return this.board.visualize();
+  }
+
   toJS(): Pojo {
     return {
       id: this.id,

--- a/src/models/tests/__snapshots__/board.test.ts.snap
+++ b/src/models/tests/__snapshots__/board.test.ts.snap
@@ -58,7 +58,7 @@ Array [
       2,
       4,
     ],
-    "id": "test-id-90",
+    "id": "test-id-284",
     "isUpsideDown": false,
     "status": "played",
   },
@@ -82,7 +82,7 @@ Array [
       2,
       4,
     ],
-    "id": "test-id-78",
+    "id": "test-id-272",
     "isUpsideDown": false,
     "status": "played",
   },
@@ -94,7 +94,7 @@ Array [
       3,
       4,
     ],
-    "id": "test-id-74",
+    "id": "test-id-268",
     "isUpsideDown": false,
     "status": "played",
   },
@@ -110,7 +110,7 @@ Array [
       3,
       4,
     ],
-    "id": "test-id-116",
+    "id": "test-id-310",
     "isUpsideDown": false,
     "status": "played",
   },
@@ -121,7 +121,7 @@ Array [
       3,
       4,
     ],
-    "id": "test-id-120",
+    "id": "test-id-314",
     "isUpsideDown": false,
     "status": "played",
   },
@@ -132,7 +132,7 @@ Array [
       3,
       4,
     ],
-    "id": "test-id-124",
+    "id": "test-id-318",
     "isUpsideDown": false,
     "status": "played",
   },
@@ -143,9 +143,45 @@ Array [
       3,
       4,
     ],
-    "id": "test-id-110",
+    "id": "test-id-304",
     "isUpsideDown": false,
     "status": "played",
   },
 ]
+`;
+
+exports[`Board visualize returns displayable version of the board 1`] = `
+"                              ██████                                          
+                              ██████                                          
+                              ██  ██                                          
+                              ██  ██                                          
+                              ██  ██                                          
+                              ██  ██                                          
+                              ██  ██                                          
+                              ██  ██                                          
+                              ██  ██                                          
+                              ██  ██                        ██████████████  ██
+                              ██  ██                        ██            !!  
+                              ██  ██                        ██  ██████████  ██
+                              ██  ██                        ██  ██            
+                              ██  ██                        ██  ██            
+                              ██  ██                        ██  ██            
+████████████████████████████████  ████████████████████████████  ██      ██  ██
+████                            []                              ██      ██xx  
+████████████████████████████████  ████████████████████████████████      ██████
+                              ██  ██                                          
+                              ██  ██                                          
+                              ██  ██                                          
+                              ██  ██                                    ██  ██
+                              ██  ██                                      xx██
+                              ██  ██                                    ██████
+                              ██  ██                                          
+                              ██  ██                                          
+                              ██  ██                                          
+                              ██  ██                                          
+                              ██  ██                                          
+                              ██  ██                                          
+                              ██  ██                                          
+                              ██████                                          
+                              ██████                                          "
 `;

--- a/src/models/tests/__snapshots__/game.test.ts.snap
+++ b/src/models/tests/__snapshots__/game.test.ts.snap
@@ -5,7 +5,7 @@ Array [
   Player {
     "age": 35,
     "hand": Object {},
-    "id": "test-id-133",
+    "id": "test-id-181",
     "isSaboteur": false,
     "name": "Alice",
     "tools": Object {
@@ -630,6 +630,24 @@ Object {
 }
 `;
 
+exports[`Game can visualize the board 1`] = `
+"                                          ██  ██
+                                            !!  
+                                          ██  ██
+                                                
+                                                
+                                                
+██  ██                                    ██  ██
+  []                                      ██xx  
+██  ██                                    ██████
+                                                
+                                                
+                                                
+                                          ██  ██
+                                            xx██
+                                          ██████"
+`;
+
 exports[`Game discardCard when game is started card is in the players hand adds a new card to the players hand 1`] = `
 Array [
   PassageCard {
@@ -770,7 +788,7 @@ Array [
 
 exports[`Game playCard when game is started card is in the players hand adds the card to the discard pile 1`] = `
 MapActionCard {
-  "id": "test-id-332",
+  "id": "test-id-380",
   "parameters": Object {
     "position": Position {
       "id": "test-id-69",
@@ -842,7 +860,7 @@ Array [
         "status": "unused",
       },
     },
-    "id": "test-id-207",
+    "id": "test-id-255",
     "isSaboteur": true,
     "name": "Player 1",
     "tools": Object {
@@ -911,7 +929,7 @@ Array [
         "status": "unused",
       },
     },
-    "id": "test-id-208",
+    "id": "test-id-256",
     "isSaboteur": false,
     "name": "Player 2",
     "tools": Object {
@@ -980,7 +998,7 @@ Array [
         "status": "unused",
       },
     },
-    "id": "test-id-209",
+    "id": "test-id-257",
     "isSaboteur": false,
     "name": "Player 3",
     "tools": Object {

--- a/src/models/tests/board.test.ts
+++ b/src/models/tests/board.test.ts
@@ -36,6 +36,105 @@ describe("Board", () => {
     expect(board.toJS()).toMatchSnapshot();
   });
 
+  describe("visualize", () => {
+    beforeEach(() => {
+      // Passage up
+      board.addCard(
+        new PassageCard([Sides.top, Sides.bottom]),
+        new Position(0, 1)
+      );
+      board.addCard(
+        new PassageCard([Sides.top, Sides.bottom]),
+        new Position(0, 2)
+      );
+      board.addCard(
+        new PassageCard([Sides.top, Sides.bottom]),
+        new Position(0, 3)
+      );
+      board.addCard(
+        new PassageCard([Sides.top, Sides.bottom]),
+        new Position(0, 4)
+      );
+      board.addCard(new DeadendCard([Sides.bottom]), new Position(0, 5));
+
+      // Passage right
+      board.addCard(
+        new PassageCard([Sides.right, Sides.left]),
+        new Position(1, 0)
+      );
+      board.addCard(
+        new PassageCard([Sides.right, Sides.left]),
+        new Position(2, 0)
+      );
+      board.addCard(
+        new PassageCard([Sides.right, Sides.left]),
+        new Position(3, 0)
+      );
+      board.addCard(
+        new PassageCard([Sides.right, Sides.left]),
+        new Position(4, 0)
+      );
+      board.addCard(
+        new PassageCard([Sides.top, Sides.left]),
+        new Position(5, 0)
+      );
+      board.addCard(
+        new PassageCard([Sides.top, Sides.bottom]),
+        new Position(5, 1)
+      );
+      board.addCard(
+        new PassageCard([Sides.right, Sides.bottom]),
+        new Position(5, 2)
+      );
+      board.addCard(
+        new PassageCard([Sides.right, Sides.left]),
+        new Position(6, 2)
+      );
+
+      // Passage down
+      board.addCard(
+        new PassageCard([Sides.top, Sides.bottom]),
+        new Position(0, -1)
+      );
+      board.addCard(
+        new PassageCard([Sides.top, Sides.bottom]),
+        new Position(0, -2)
+      );
+      board.addCard(
+        new PassageCard([Sides.top, Sides.bottom]),
+        new Position(0, -3)
+      );
+      board.addCard(
+        new PassageCard([Sides.top, Sides.bottom]),
+        new Position(0, -4)
+      );
+      board.addCard(new DeadendCard([Sides.top]), new Position(0, -5));
+
+      // Passage left
+      board.addCard(
+        new PassageCard([Sides.right, Sides.left]),
+        new Position(-1, 0)
+      );
+      board.addCard(
+        new PassageCard([Sides.right, Sides.left]),
+        new Position(-2, 0)
+      );
+      board.addCard(
+        new PassageCard([Sides.right, Sides.left]),
+        new Position(-3, 0)
+      );
+      board.addCard(
+        new PassageCard([Sides.right, Sides.left]),
+        new Position(-4, 0)
+      );
+      board.addCard(new DeadendCard([Sides.right]), new Position(-5, 0));
+    });
+
+    it("returns displayable version of the board", () => {
+      expect(board.visualize()).toMatchSnapshot();
+    });
+  });
+
   describe("get card from board", () => {
     describe("when start position provided", () => {
       it("returns start card", () => {

--- a/src/models/tests/game.test.ts
+++ b/src/models/tests/game.test.ts
@@ -49,6 +49,10 @@ describe("Game", () => {
     expect(game.toJS()).toMatchSnapshot();
   });
 
+  it("can visualize the board", () => {
+    expect(game.visualizeBoard()).toMatchSnapshot();
+  });
+
   describe("on event", () => {
     const mockEventHandler = jest.fn();
 

--- a/src/utils/can-cards-connect/index.ts
+++ b/src/utils/can-cards-connect/index.ts
@@ -1,11 +1,6 @@
 import { Sides } from "../../models/cards/card";
 import { TunnelCard } from "../../models/cards/path-cards";
-import { SPACE_SIDES } from "../../constants";
-
-export const getOppositeSide = (side: Sides): Sides => {
-  if (!Sides[side]) throw new Error("Unknown side");
-  return (side + SPACE_SIDES / 2) % SPACE_SIDES || SPACE_SIDES;
-};
+import { getOppositeSide } from "../get-opposite-side";
 
 function canCardsConnect(
   side: Sides,

--- a/src/utils/can-cards-connect/tests/index.test.ts
+++ b/src/utils/can-cards-connect/tests/index.test.ts
@@ -4,7 +4,7 @@ import {
   TunnelCard,
 } from "../../../models/cards/path-cards";
 import { Sides } from "../../../models/cards/card";
-import canCardsConnect, { getOppositeSide } from "..";
+import canCardsConnect from "..";
 
 const sideName = ["top", "right", "bottom", "left"];
 
@@ -51,7 +51,7 @@ describe("check two cards can connect", () => {
   ] as typeof TunnelCard[][])(
     "when connecting %p with %p",
     (AdjacentCardType: typeof TunnelCard, CardType: typeof TunnelCard) => {
-      describe("when both cards are right-side up", () => {
+      describe("when both cards are right side up", () => {
         describe.each([
           ...commonTestCases,
           [
@@ -173,26 +173,4 @@ describe("check two cards can connect", () => {
       });
     }
   );
-});
-
-describe("getOppositeSide", () => {
-  it("returns bottom given top", () => {
-    expect(getOppositeSide(Sides.top)).toBe(Sides.bottom);
-  });
-
-  it("returns left given right", () => {
-    expect(getOppositeSide(Sides.right)).toBe(Sides.left);
-  });
-
-  it("returns top given bottom", () => {
-    expect(getOppositeSide(Sides.bottom)).toBe(Sides.top);
-  });
-
-  it("returns right given left", () => {
-    expect(getOppositeSide(Sides.left)).toBe(Sides.right);
-  });
-
-  it("throw execption given unknown side", () => {
-    expect(() => getOppositeSide(0)).toThrow("Unknown side");
-  });
 });

--- a/src/utils/get-card-visualization/index.ts
+++ b/src/utils/get-card-visualization/index.ts
@@ -1,0 +1,19 @@
+import { Sides } from "../../models/cards/card";
+import { PathCard } from "../../models/cards/path-cards";
+import { getOppositeSide } from "../get-opposite-side";
+
+const getCardVisualization = (card: PathCard, center = "  "): string => {
+  const getConnection = (passedSide: Sides): string => {
+    const side = card.isUpsideDown ? getOppositeSide(passedSide) : passedSide;
+    if (card.connectors.includes(side)) return "  ";
+    return "██";
+  };
+  const top = `██${getConnection(Sides.top)}██`;
+  const middle = `${getConnection(Sides.left)}${center}${getConnection(
+    Sides.right
+  )}`;
+  const bottom = `██${getConnection(Sides.bottom)}██`;
+  return `${top}\n${middle}\n${bottom}`;
+};
+
+export default getCardVisualization;

--- a/src/utils/get-opposite-side/index.test.ts
+++ b/src/utils/get-opposite-side/index.test.ts
@@ -1,0 +1,24 @@
+import { Sides } from "../../models/cards/card";
+import { getOppositeSide } from ".";
+
+describe("getOppositeSide", () => {
+  it("returns bottom given top", () => {
+    expect(getOppositeSide(Sides.top)).toBe(Sides.bottom);
+  });
+
+  it("returns left given right", () => {
+    expect(getOppositeSide(Sides.right)).toBe(Sides.left);
+  });
+
+  it("returns top given bottom", () => {
+    expect(getOppositeSide(Sides.bottom)).toBe(Sides.top);
+  });
+
+  it("returns right given left", () => {
+    expect(getOppositeSide(Sides.left)).toBe(Sides.right);
+  });
+
+  it("throw execption given unknown side", () => {
+    expect(() => getOppositeSide(0)).toThrow("Unknown side");
+  });
+});

--- a/src/utils/get-opposite-side/index.ts
+++ b/src/utils/get-opposite-side/index.ts
@@ -1,0 +1,7 @@
+import { Sides } from "../../models/cards/card";
+import { SPACE_SIDES } from "../../constants";
+
+export const getOppositeSide = (side: Sides): Sides => {
+  if (!Sides[side]) throw new Error("Unknown side");
+  return (side + SPACE_SIDES / 2) % SPACE_SIDES || SPACE_SIDES;
+};


### PR DESCRIPTION
Adds visual output for the board and cards. Example has been updated to
shows visual of the cards being played and the board when complete.

<img width="712" alt="Screenshot 2020-06-06 at 17 28 57" src="https://user-images.githubusercontent.com/635903/83954483-7f483280-a841-11ea-819b-f8f1c91e8c05.png">
