### PR TITLE
Fix position of finish cards

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -23,13 +23,15 @@ players.forEach((player) => {
 
 game.start();
 
-for (let i = 1; i <= 5; i++) {
+for (let i = 1; i <= 7; i++) {
   const player = game.getActivePlayer() as Player;
   const playableCard = player
     .getHand()
     .find(
       (card) =>
-        card instanceof PassageCard && card.connectors.includes(Sides.left)
+        card instanceof PassageCard &&
+        card.connectors.includes(Sides.left) &&
+        card.connectors.includes(Sides.right)
     );
 
   if (playableCard) {

--- a/src/models/board.ts
+++ b/src/models/board.ts
@@ -16,9 +16,9 @@ interface IGrid {
 }
 
 export const startPosition = new Position(0, 0);
-export const topFinishPosition = new Position(7, 2);
-export const middleFinishPosition = new Position(7, 0);
-export const bottomFinishPosition = new Position(7, -2);
+export const topFinishPosition = new Position(8, 2);
+export const middleFinishPosition = new Position(8, 0);
+export const bottomFinishPosition = new Position(8, -2);
 
 class Board {
   id: string;

--- a/src/models/tests/__snapshots__/board.test.ts.snap
+++ b/src/models/tests/__snapshots__/board.test.ts.snap
@@ -14,7 +14,7 @@ Object {
       "isUpsideDown": false,
       "status": "played",
     },
-    "7,-2": RockFinishPathCard {
+    "8,-2": RockFinishPathCard {
       "connectors": Array [
         1,
         4,
@@ -23,7 +23,7 @@ Object {
       "isUpsideDown": false,
       "status": "played",
     },
-    "7,0": RockFinishPathCard {
+    "8,0": RockFinishPathCard {
       "connectors": Array [
         1,
         2,
@@ -32,7 +32,7 @@ Object {
       "isUpsideDown": false,
       "status": "played",
     },
-    "7,2": GoldFinishPathCard {
+    "8,2": GoldFinishPathCard {
       "connectors": Array [
         1,
         2,
@@ -235,50 +235,50 @@ Array [
 ]
 `;
 
-exports[`Board get available positions from the board when there is a passage formed returns correct positions for continuing the passage  2`] = `
+exports[`Board get available positions from the board when there is a passage formed to a finish path card returns correct positions for continuing the passage  1`] = `
 Array [
   Position {
-    "id": "test-id-165",
+    "id": "test-id-197",
     "x": 0,
     "y": 1,
   },
   Position {
-    "id": "test-id-166",
+    "id": "test-id-198",
     "x": 1,
     "y": 0,
   },
   Position {
-    "id": "test-id-176",
+    "id": "test-id-208",
     "x": 4,
     "y": -1,
   },
   Position {
-    "id": "test-id-178",
+    "id": "test-id-210",
     "x": 5,
     "y": -1,
   },
   Position {
-    "id": "test-id-181",
-    "x": 7,
+    "id": "test-id-214",
+    "x": 8,
     "y": -1,
   },
   Position {
-    "id": "test-id-185",
+    "id": "test-id-219",
     "x": 4,
     "y": -3,
   },
   Position {
-    "id": "test-id-189",
+    "id": "test-id-223",
     "x": 1,
     "y": -2,
   },
   Position {
-    "id": "test-id-191",
+    "id": "test-id-225",
     "x": 0,
     "y": -2,
   },
   Position {
-    "id": "test-id-192",
+    "id": "test-id-226",
     "x": -1,
     "y": 0,
   },
@@ -346,37 +346,37 @@ Array [
 `;
 
 exports[`Board visualize returns displayable version of the board 1`] = `
-"                              ██████                                                
-                              ██████                                                
-                              ██  ██                                                
-                              ██  ██                                                
-                              ██  ██                                                
-                              ██  ██                                                
-                              ██  ██                                    |‾‾‾‾|      
-                              ██  ██                                    |    |      
-                              ██  ██                                    |____|      
-                              ██  ██                        ██████████████  ██|‾‾‾‾|
-                              ██  ██                        ██            !!  |    |
-                              ██  ██                        ██  ██████████  ██|____|
-                              ██  ██                        ██  ██      |‾‾‾‾|      
-                              ██  ██                        ██  ██      |    |      
-                              ██  ██                        ██  ██      |____|      
-████████████████████████████████  ████████████████████████████  ██      ██  ██      
-████                            []                              ██      ██xx        
-████████████████████████████████  ████████████████████████████████      ██████      
-                              ██  ██                                                
-                              ██  ██                                                
-                              ██  ██                                                
-                              ██  ██                                    ██  ██      
-                              ██  ██                                      xx██      
-                              ██  ██                                    ██████      
-                              ██  ██                                                
-                              ██  ██                                                
-                              ██  ██                                                
-                              ██  ██                                                
-                              ██  ██                                                
-                              ██  ██                                                
-                              ██  ██                                                
-                              ██████                                                
-                              ██████                                                "
+"                              ██████                                                      
+                              ██████                                                      
+                              ██  ██                                                      
+                              ██  ██                                                      
+                              ██  ██                                                      
+                              ██  ██                                                      
+                              ██  ██                                          |‾‾‾‾|      
+                              ██  ██                                          |    |      
+                              ██  ██                                          |____|      
+                              ██  ██                              ██████████████  ██|‾‾‾‾|
+                              ██  ██                              ██            !!  |    |
+                              ██  ██                              ██  ██████████  ██|____|
+                              ██  ██                              ██  ██      |‾‾‾‾|      
+                              ██  ██                              ██  ██      |    |      
+                              ██  ██                              ██  ██      |____|      
+████████████████████████████████  ██████████████████████████████████  ██      ██  ██      
+████                            []                                    ██      ██xx        
+████████████████████████████████  ██████████████████████████████████████      ██████      
+                              ██  ██                                                      
+                              ██  ██                                                      
+                              ██  ██                                                      
+                              ██  ██                                          ██  ██      
+                              ██  ██                                            xx██      
+                              ██  ██                                          ██████      
+                              ██  ██                                                      
+                              ██  ██                                                      
+                              ██  ██                                                      
+                              ██  ██                                                      
+                              ██  ██                                                      
+                              ██  ██                                                      
+                              ██  ██                                                      
+                              ██████                                                      
+                              ██████                                                      "
 `;

--- a/src/models/tests/__snapshots__/game.test.ts.snap
+++ b/src/models/tests/__snapshots__/game.test.ts.snap
@@ -33,7 +33,7 @@ Object {
         "isUpsideDown": false,
         "status": "played",
       },
-      "7,-2": RockFinishPathCard {
+      "8,-2": RockFinishPathCard {
         "connectors": Array [
           1,
           4,
@@ -42,7 +42,7 @@ Object {
         "isUpsideDown": false,
         "status": "played",
       },
-      "7,0": RockFinishPathCard {
+      "8,0": RockFinishPathCard {
         "connectors": Array [
           1,
           2,
@@ -51,7 +51,7 @@ Object {
         "isUpsideDown": false,
         "status": "played",
       },
-      "7,2": GoldFinishPathCard {
+      "8,2": GoldFinishPathCard {
         "connectors": Array [
           1,
           2,
@@ -631,21 +631,21 @@ Object {
 `;
 
 exports[`Game can visualize the board 1`] = `
-"                                                ██  ██
-                                                  !!  
-                                                ██  ██
-      |‾‾‾‾|                                          
-      |    |                                          
-      |____|                                          
-|‾‾‾‾|██  ██|‾‾‾‾|                              ██  ██
-|    |  []  |    |                              ██xx  
-|____|██  ██|____|                              ██████
-      |‾‾‾‾|                                          
-      |    |                                          
-      |____|                                          
-                                                ██  ██
-                                                  xx██
-                                                ██████"
+"                                                      ██  ██
+                                                        !!  
+                                                      ██  ██
+      |‾‾‾‾|                                                
+      |    |                                                
+      |____|                                                
+|‾‾‾‾|██  ██|‾‾‾‾|                                    ██  ██
+|    |  []  |    |                                    ██xx  
+|____|██  ██|____|                                    ██████
+      |‾‾‾‾|                                                
+      |    |                                                
+      |____|                                                
+                                                      ██  ██
+                                                        xx██
+                                                      ██████"
 `;
 
 exports[`Game discardCard when game is started card is in the players hand adds a new card to the players hand 1`] = `
@@ -792,7 +792,7 @@ MapActionCard {
   "parameters": Object {
     "position": Position {
       "id": "test-id-69",
-      "x": 7,
+      "x": 8,
       "y": 0,
     },
   },

--- a/src/models/tests/board.test.ts
+++ b/src/models/tests/board.test.ts
@@ -75,20 +75,24 @@ describe("Board", () => {
         new Position(4, 0)
       );
       board.addCard(
-        new PassageCard([Sides.top, Sides.left]),
+        new PassageCard([Sides.right, Sides.left]),
         new Position(5, 0)
       );
       board.addCard(
+        new PassageCard([Sides.top, Sides.left]),
+        new Position(6, 0)
+      );
+      board.addCard(
         new PassageCard([Sides.top, Sides.bottom]),
-        new Position(5, 1)
+        new Position(6, 1)
       );
       board.addCard(
         new PassageCard([Sides.right, Sides.bottom]),
-        new Position(5, 2)
+        new Position(6, 2)
       );
       board.addCard(
         new PassageCard([Sides.right, Sides.left]),
-        new Position(6, 2)
+        new Position(7, 2)
       );
 
       // Passage down
@@ -529,7 +533,7 @@ describe("Board", () => {
       });
     });
 
-    describe("when there is a passage formed", () => {
+    describe("when there is a passage formed to a finish path card", () => {
       beforeEach(() => {
         board.addCard(
           new PassageCard([Sides.top, Sides.right, Sides.bottom]),
@@ -562,6 +566,10 @@ describe("Board", () => {
         board.addCard(
           new PassageCard([Sides.right, Sides.left]),
           new Position(6, -2)
+        );
+        board.addCard(
+          new PassageCard([Sides.right, Sides.left]),
+          new Position(7, -2)
         );
       });
 


### PR DESCRIPTION
Finish cards have been updated to column index 8, so that there are 7
cards between the starting card column and the finish card column, as
per the rules.

![image](https://user-images.githubusercontent.com/635903/83976544-79f6f080-a8f2-11ea-9c5f-18edf2ad5c02.png)
