### PR TITLE
Implement functionality for connecting to final path

### DIFF
--- a/src/models/cards/index.ts
+++ b/src/models/cards/index.ts
@@ -83,16 +83,10 @@ export interface IPlacedCards {
 }
 
 export const getPlacedCards = (): IPlacedCards => {
-  const start = new StartPathCard(randomBoolean());
-  const gold = new GoldFinishPathCard(randomBoolean());
-  const rock1 = new RockFinishPathCard(
-    [Sides.top, Sides.right],
-    randomBoolean()
-  );
-  const rock2 = new RockFinishPathCard(
-    [Sides.top, Sides.left],
-    randomBoolean()
-  );
+  const start = new StartPathCard();
+  const gold = new GoldFinishPathCard();
+  const rock1 = new RockFinishPathCard([Sides.top, Sides.right]);
+  const rock2 = new RockFinishPathCard([Sides.top, Sides.left]);
 
   [start, gold, rock1, rock2].forEach((card) => card.setPlayed());
 

--- a/src/models/cards/path-cards/boundary-cards.ts
+++ b/src/models/cards/path-cards/boundary-cards.ts
@@ -2,6 +2,8 @@ import { PathCard } from ".";
 import { Sides } from "../card";
 import getCardVisualization from "../../../utils/get-card-visualization";
 
+const UNKNOWN_CARD = "▕▔▔▔▔▏\n▕ ?? ▏\n▕▁▁▁▁▏";
+
 export class StartPathCard extends PathCard {
   constructor(isUpsideDown?: boolean) {
     super([Sides.top, Sides.right, Sides.bottom, Sides.left], isUpsideDown);
@@ -12,7 +14,21 @@ export class StartPathCard extends PathCard {
   }
 }
 
-export class FinishPathCard extends PathCard {}
+export class FinishPathCard extends PathCard {
+  isFaceDown: boolean;
+
+  constructor(connectors: Sides[], isUpsideDown?: boolean) {
+    super(connectors, isUpsideDown);
+    this.isFaceDown = true;
+  }
+
+  turnOver(side: Sides): void {
+    this.isFaceDown = false;
+    if (!this.connectors.includes(side)) {
+      this.rotate();
+    }
+  }
+}
 
 export class GoldFinishPathCard extends FinishPathCard {
   constructor(isUpsideDown?: boolean) {
@@ -20,12 +36,14 @@ export class GoldFinishPathCard extends FinishPathCard {
   }
 
   visualize(): string {
+    if (this.isFaceDown) return UNKNOWN_CARD;
     return getCardVisualization(this, "!!");
   }
 }
 
 export class RockFinishPathCard extends FinishPathCard {
   visualize(): string {
+    if (this.isFaceDown) return UNKNOWN_CARD;
     return getCardVisualization(this, "xx");
   }
 }

--- a/src/models/cards/path-cards/tests/__snapshots__/boundary-cards.test.ts.snap
+++ b/src/models/cards/path-cards/tests/__snapshots__/boundary-cards.test.ts.snap
@@ -1,18 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Boundary Cards GoldFinishPathCard can be visualized 1`] = `
+exports[`Boundary Cards GoldFinishPathCard when face down can be visualized 1`] = `
+"▕▔▔▔▔▏
+▕ ?? ▏
+▕▁▁▁▁▏"
+`;
+
+exports[`Boundary Cards GoldFinishPathCard when face up can be visualized 1`] = `
 "██  ██
   !!  
 ██  ██"
 `;
 
-exports[`Boundary Cards GoldFinishPathCard can be visualized right side up 1`] = `
+exports[`Boundary Cards RockFinishPathCard when face down can be visualized right side up 1`] = `
+"▕▔▔▔▔▏
+▕ ?? ▏
+▕▁▁▁▁▏"
+`;
+
+exports[`Boundary Cards RockFinishPathCard when face down can be visualized upside down 1`] = `
+"▕▔▔▔▔▏
+▕ ?? ▏
+▕▁▁▁▁▏"
+`;
+
+exports[`Boundary Cards RockFinishPathCard when face up can be visualized right side up 1`] = `
 "██  ██
 ██xx  
 ██████"
 `;
 
-exports[`Boundary Cards GoldFinishPathCard can be visualized upside down 1`] = `
+exports[`Boundary Cards RockFinishPathCard when face up can be visualized upside down 1`] = `
 "██████
   xx██
 ██  ██"

--- a/src/models/cards/path-cards/tests/boundary-cards.test.ts
+++ b/src/models/cards/path-cards/tests/boundary-cards.test.ts
@@ -1,5 +1,10 @@
 import { Sides } from "../../card";
-import { StartPathCard, GoldFinishPathCard, RockFinishPathCard } from "..";
+import {
+  StartPathCard,
+  GoldFinishPathCard,
+  RockFinishPathCard,
+  FinishPathCard,
+} from "..";
 
 describe("Boundary Cards", () => {
   describe("StartPathCard", () => {
@@ -8,23 +13,98 @@ describe("Boundary Cards", () => {
     });
   });
 
-  describe("GoldFinishPathCard", () => {
-    it("can be visualized", () => {
-      expect(new GoldFinishPathCard().visualize()).toMatchSnapshot();
+  describe("FinishPathCard", () => {
+    let card: FinishPathCard;
+
+    beforeEach(() => {
+      card = new FinishPathCard([Sides.top, Sides.right]);
+    });
+
+    it("is face down by default", () => {
+      expect(card.isFaceDown).toBe(true);
+    });
+
+    describe("turnOver", () => {
+      describe("when connected to on a side with a connector", () => {
+        beforeEach(() => {
+          card.turnOver(Sides.top);
+        });
+
+        it("turns over the card and does not rotate", () => {
+          expect(card.isFaceDown).toBe(false);
+          expect(card.isUpsideDown).toBe(false);
+        });
+      });
+
+      describe("when connected to on a side without a connector", () => {
+        beforeEach(() => {
+          card.turnOver(Sides.bottom);
+        });
+
+        it("turns over the card and rotates to match connector", () => {
+          expect(card.isFaceDown).toBe(false);
+          expect(card.isUpsideDown).toBe(true);
+        });
+      });
     });
   });
 
   describe("GoldFinishPathCard", () => {
-    it("can be visualized right side up", () => {
-      expect(
-        new RockFinishPathCard([Sides.top, Sides.right], false).visualize()
-      ).toMatchSnapshot();
+    let card: GoldFinishPathCard;
+
+    beforeEach(() => {
+      card = new GoldFinishPathCard();
     });
 
-    it("can be visualized upside down", () => {
-      expect(
-        new RockFinishPathCard([Sides.top, Sides.right], true).visualize()
-      ).toMatchSnapshot();
+    describe("when face down", () => {
+      it("can be visualized", () => {
+        expect(card.visualize()).toMatchSnapshot();
+      });
+    });
+
+    describe("when face up", () => {
+      beforeEach(() => {
+        card.turnOver(Sides.left);
+      });
+
+      it("can be visualized", () => {
+        expect(card.visualize()).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe("RockFinishPathCard", () => {
+    let cardRightSideUp: RockFinishPathCard;
+    let cardUpsideDown: RockFinishPathCard;
+
+    beforeEach(() => {
+      cardRightSideUp = new RockFinishPathCard([Sides.top, Sides.right], false);
+      cardUpsideDown = new RockFinishPathCard([Sides.top, Sides.right], true);
+    });
+
+    describe("when face down", () => {
+      it("can be visualized right side up", () => {
+        expect(cardRightSideUp.visualize()).toMatchSnapshot();
+      });
+
+      it("can be visualized upside down", () => {
+        expect(cardUpsideDown.visualize()).toMatchSnapshot();
+      });
+    });
+
+    describe("when face up", () => {
+      beforeEach(() => {
+        cardRightSideUp.turnOver(Sides.top);
+        cardUpsideDown.turnOver(Sides.top);
+      });
+
+      it("can be visualized right side up", () => {
+        expect(cardRightSideUp.visualize()).toMatchSnapshot();
+      });
+
+      it("can be visualized upside down", () => {
+        expect(cardUpsideDown.visualize()).toMatchSnapshot();
+      });
     });
   });
 });

--- a/src/models/game.ts
+++ b/src/models/game.ts
@@ -102,12 +102,16 @@ class Game {
 
   private endTurn(): void {
     eventEmitter.emit("end-turn", this.getActivePlayer());
+    if (this.board.isComplete) return;
+
     this.turn += 1;
     eventEmitter.emit("start-turn", this.getActivePlayer());
   }
 
   getActivePlayer(): Player | undefined {
-    if (!this.isStarted) return undefined;
+    if (!this.isStarted || this.isFinished) {
+      return undefined;
+    }
 
     const playerIndex = this.turn % this.playOrder.length;
     const activePlayerId = this.playOrder[playerIndex];
@@ -141,6 +145,12 @@ class Game {
     if (drawnCard) player.addToHand(drawnCard);
 
     this.endTurn();
+
+    if (this.board.isComplete) {
+      this.isFinished = true;
+      // TODO: allocate points, set the round to complete, reset board, reset the deck, reshuffle the finish cards, reshuffle saboteurs, etc.
+      eventEmitter.emit("end-game");
+    }
   }
 
   discardCard(player: Player, cardId?: string): void {

--- a/src/models/tests/__snapshots__/board.test.ts.snap
+++ b/src/models/tests/__snapshots__/board.test.ts.snap
@@ -20,6 +20,7 @@ Object {
         4,
       ],
       "id": "test-id-4",
+      "isFaceDown": true,
       "isUpsideDown": false,
       "status": "played",
     },
@@ -29,6 +30,7 @@ Object {
         2,
       ],
       "id": "test-id-3",
+      "isFaceDown": true,
       "isUpsideDown": false,
       "status": "played",
     },
@@ -40,6 +42,7 @@ Object {
         4,
       ],
       "id": "test-id-2",
+      "isFaceDown": true,
       "isUpsideDown": false,
       "status": "played",
     },
@@ -48,7 +51,7 @@ Object {
 }
 `;
 
-exports[`Board get adjacent cards from the board when the position is beside a finish card returns surrounding cards but not the finish card 1`] = `
+exports[`Board get adjacent cards from the board when the position is beside a finish card returns surrounding cards including finish card 1`] = `
 Array [
   undefined,
   undefined,
@@ -352,18 +355,18 @@ exports[`Board visualize returns displayable version of the board 1`] = `
                               ██  ██                                                      
                               ██  ██                                                      
                               ██  ██                                                      
-                              ██  ██                                          |‾‾‾‾|      
-                              ██  ██                                          |    |      
-                              ██  ██                                          |____|      
-                              ██  ██                              ██████████████  ██|‾‾‾‾|
-                              ██  ██                              ██            !!  |    |
-                              ██  ██                              ██  ██████████  ██|____|
-                              ██  ██                              ██  ██      |‾‾‾‾|      
-                              ██  ██                              ██  ██      |    |      
-                              ██  ██                              ██  ██      |____|      
-████████████████████████████████  ██████████████████████████████████  ██      ██  ██      
-████                            []                                    ██      ██xx        
-████████████████████████████████  ██████████████████████████████████████      ██████      
+                              ██  ██                                          ╭┄┄┄┄╮      
+                              ██  ██                                          │    │      
+                              ██  ██                                          ╰┄┄┄┄╯      
+                              ██  ██                              ██████████████  ██╭┄┄┄┄╮
+                              ██  ██                              ██            !!  │    │
+                              ██  ██                              ██  ██████████  ██╰┄┄┄┄╯
+                              ██  ██                              ██  ██      ╭┄┄┄┄╮      
+                              ██  ██                              ██  ██      │    │      
+                              ██  ██                              ██  ██      ╰┄┄┄┄╯      
+████████████████████████████████  ██████████████████████████████████  ██      ██████      
+████                            []                                    ██        xx██      
+████████████████████████████████  ██████████████████████████████████████      ██  ██      
                               ██  ██                                                      
                               ██  ██                                                      
                               ██  ██                                                      

--- a/src/models/tests/__snapshots__/game.test.ts.snap
+++ b/src/models/tests/__snapshots__/game.test.ts.snap
@@ -39,6 +39,7 @@ Object {
           4,
         ],
         "id": "test-id-7",
+        "isFaceDown": true,
         "isUpsideDown": false,
         "status": "played",
       },
@@ -48,6 +49,7 @@ Object {
           2,
         ],
         "id": "test-id-6",
+        "isFaceDown": true,
         "isUpsideDown": false,
         "status": "played",
       },
@@ -59,11 +61,13 @@ Object {
           4,
         ],
         "id": "test-id-5",
+        "isFaceDown": true,
         "isUpsideDown": false,
         "status": "played",
       },
     },
     "id": "test-id-3",
+    "isComplete": false,
   },
   "deck": Deck {
     "drawPile": Array [
@@ -631,21 +635,21 @@ Object {
 `;
 
 exports[`Game can visualize the board 1`] = `
-"                                                      ██  ██
-                                                        !!  
-                                                      ██  ██
-      |‾‾‾‾|                                                
-      |    |                                                
-      |____|                                                
-|‾‾‾‾|██  ██|‾‾‾‾|                                    ██  ██
-|    |  []  |    |                                    ██xx  
-|____|██  ██|____|                                    ██████
-      |‾‾‾‾|                                                
-      |    |                                                
-      |____|                                                
-                                                      ██  ██
-                                                        xx██
-                                                      ██████"
+"                                                      ▕▔▔▔▔▏
+                                                      ▕ ?? ▏
+                                                      ▕▁▁▁▁▏
+      ╭┄┄┄┄╮                                                
+      │    │                                                
+      ╰┄┄┄┄╯                                                
+╭┄┄┄┄╮██  ██╭┄┄┄┄╮                                    ▕▔▔▔▔▏
+│    │  []  │    │                                    ▕ ?? ▏
+╰┄┄┄┄╯██  ██╰┄┄┄┄╯                                    ▕▁▁▁▁▏
+      ╭┄┄┄┄╮                                                
+      │    │                                                
+      ╰┄┄┄┄╯                                                
+                                                      ▕▔▔▔▔▏
+                                                      ▕ ?? ▏
+                                                      ▕▁▁▁▁▏"
 `;
 
 exports[`Game discardCard when game is started card is in the players hand adds a new card to the players hand 1`] = `

--- a/src/utils/can-cards-connect/index.ts
+++ b/src/utils/can-cards-connect/index.ts
@@ -1,5 +1,5 @@
 import { Sides } from "../../models/cards/card";
-import { TunnelCard } from "../../models/cards/path-cards";
+import { TunnelCard, FinishPathCard } from "../../models/cards/path-cards";
 import { getOppositeSide } from "../get-opposite-side";
 
 function canCardsConnect(
@@ -8,6 +8,11 @@ function canCardsConnect(
   card: TunnelCard
 ): boolean {
   if (!adjacentCard) return true;
+
+  // Finish paths can always be connected to when face down
+  if (adjacentCard instanceof FinishPathCard && adjacentCard.isFaceDown) {
+    return true;
+  }
 
   const cardConnectors = card.connectors.map((connector) =>
     card.isUpsideDown ? getOppositeSide(connector) : connector

--- a/src/utils/can-cards-connect/tests/index.test.ts
+++ b/src/utils/can-cards-connect/tests/index.test.ts
@@ -2,6 +2,7 @@ import {
   PassageCard,
   DeadendCard,
   TunnelCard,
+  RockFinishPathCard,
 } from "../../../models/cards/path-cards";
 import { Sides } from "../../../models/cards/card";
 import canCardsConnect from "..";
@@ -173,4 +174,38 @@ describe("check two cards can connect", () => {
       });
     }
   );
+
+  describe("connecting to a final card", () => {
+    let adjacentCard: RockFinishPathCard;
+    let card: PassageCard;
+
+    beforeEach(() => {
+      adjacentCard = new RockFinishPathCard([Sides.top, Sides.right]);
+      card = new PassageCard([Sides.right, Sides.left]);
+    });
+
+    describe("when the final card is face down", () => {
+      it("connects when connectors match", () => {
+        expect(canCardsConnect(Sides.left, adjacentCard, card)).toBe(true);
+      });
+
+      it("connects when connectors don't match", () => {
+        expect(canCardsConnect(Sides.right, adjacentCard, card)).toBe(true);
+      });
+    });
+
+    describe("when the final card is face up", () => {
+      beforeEach(() => {
+        adjacentCard.turnOver(Sides.top);
+      });
+
+      it("connects when connectors match", () => {
+        expect(canCardsConnect(Sides.left, adjacentCard, card)).toBe(true);
+      });
+
+      it("connects when connectors don't match", () => {
+        expect(canCardsConnect(Sides.right, adjacentCard, card)).toBe(false);
+      });
+    });
+  });
 });


### PR DESCRIPTION
This work included setting final path cards to be face down (and
updating visualisation), turn face up when being connected to (but
detect when just placing a card beside the final path), rotating the
final card so that it matches the direction of connection, reveal all
cards when connecting to the gold final path, reveal multiple final path
cards when the connecting card can connect to more than one.

### Connecting to gold
![image](https://user-images.githubusercontent.com/635903/83983042-05887580-a923-11ea-8f1c-b53f159e75b5.png)

### Connecting to rock
![image](https://user-images.githubusercontent.com/635903/83983005-d6720400-a922-11ea-898a-97fb9ea670d4.png)

Fixes #16