### PR TITLE
Bug fix for placing upside down card beside finish card

### DIFF
--- a/src/models/board.ts
+++ b/src/models/board.ts
@@ -144,7 +144,13 @@ class Board {
 
         // Check we are actually trying to connect to the finish path card
         // and not just placing a card beside it
-        if (!card.connectors.includes(side)) return;
+        if (
+          (!card.isUpsideDown && !card.connectors.includes(side)) ||
+          (card.isUpsideDown &&
+            !card.connectors.includes(getOppositeSide(side)))
+        ) {
+          return;
+        }
 
         adjacentFinishPathCard.turnOver(getOppositeSide(side));
 

--- a/src/models/tests/board.test.ts
+++ b/src/models/tests/board.test.ts
@@ -269,6 +269,48 @@ describe("Board", () => {
         });
       });
 
+      describe("and card is in between two finish cards", () => {
+        beforeEach(() => {
+          traverseBoard(board);
+          board.addCard(
+            new PassageCard([Sides.bottom, Sides.left]),
+            new Position(7, 0)
+          );
+          board.addCard(
+            new PassageCard([Sides.top, Sides.right]),
+            new Position(7, -1)
+          );
+        });
+
+        it("turns over the middle finish card when right side up", () => {
+          expect(isFaceDown(board, topFinishPosition)).toBe(true);
+          expect(isFaceDown(board, middleFinishPosition)).toBe(true);
+          expect(isFaceDown(board, bottomFinishPosition)).toBe(true);
+          board.addCard(
+            new PassageCard([Sides.top, Sides.right, Sides.left]),
+            new Position(8, -1)
+          );
+          expect(isFaceDown(board, topFinishPosition)).toBe(true);
+          expect(isFaceDown(board, middleFinishPosition)).toBe(false);
+          expect(isFaceDown(board, bottomFinishPosition)).toBe(true);
+          expect(board.isComplete).toBe(false);
+        });
+
+        it("turns over the bottom finish card when upside-down", () => {
+          expect(isFaceDown(board, topFinishPosition)).toBe(true);
+          expect(isFaceDown(board, middleFinishPosition)).toBe(true);
+          expect(isFaceDown(board, bottomFinishPosition)).toBe(true);
+          board.addCard(
+            new PassageCard([Sides.top, Sides.right, Sides.left], true),
+            new Position(8, -1)
+          );
+          expect(isFaceDown(board, topFinishPosition)).toBe(true);
+          expect(isFaceDown(board, middleFinishPosition)).toBe(true);
+          expect(isFaceDown(board, bottomFinishPosition)).toBe(false);
+          expect(board.isComplete).toBe(false);
+        });
+      });
+
       describe("and card connects to finish card", () => {
         beforeEach(() => {
           traverseBoard(board);


### PR DESCRIPTION
Fixes an issue where the card orientation wasn't taken into account when
deciding whether the finish card should be turned over. This mean that a
finish card may have been erroneously been turned over, may not have
turned over when expected to, or in some situations have turned over the
wrong finish card.